### PR TITLE
Import selector name in Landing screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
+.idea
 dist/main.js
 dist/main.css

--- a/src/screens/Landing/style.scss
+++ b/src/screens/Landing/style.scss
@@ -1,5 +1,6 @@
 @import "helpers";
+@value wrapper from '../../components/Label/style.scss';
 
-.form > :global(.src-components-Label-style__wrapper) {
+.form > .wrapper {
   color: blue;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,9 +25,10 @@ module.exports = {
           {
             loader: "css-loader",
             options: {
-              localsConvention: "camelCase",
+              localsConvention: "camelCaseOnly",
               modules: {
-                localIdentName: "[path][name]__[local]"
+                localIdentName: "[path][name]__[local]",
+                context: path.resolve(__dirname, 'src/components'),
               },
               importLoaders: 1
             }


### PR DESCRIPTION
- add `.idea` to .gitignore
- force camelCase only class names
- add context to generate shorter class names for components `Label-style__wrapper` vs `src-components-Label-style__wrapper`